### PR TITLE
Types export, stream destroy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from './methods/passthrough';
 export * from './methods/reduce';
 export * from './methods/to';
 export * from './methods/transform';
+export * from './types';

--- a/src/methods/chunk.ts
+++ b/src/methods/chunk.ts
@@ -1,28 +1,9 @@
-import { Transform } from "stream";
 import { TransformTyped, TransformTypedOptions } from "../types";
+import { chunkMap } from "./chunkMap";
 
 export function chunk<R>(
   size: number,
   options: TransformTypedOptions<R, R[]> = {}
 ): TransformTyped<R, R[]> {
-  let chunk: R[] = [];
-  return new Transform({
-    objectMode: true,
-    ...options,
-    transform(item, _encoding, callback) {
-      chunk.push(item);
-      if (chunk.length >= size) {
-        this.push(chunk);
-        chunk = [];
-      }
-      callback();
-    },
-    flush(callback) {
-      if (chunk.length > 0) {
-        this.push(chunk);
-        chunk = [];
-      }
-      callback();
-    }
-  });
+  return chunkMap(size, (chunk) => chunk, options);
 }

--- a/src/methods/chunkMap.ts
+++ b/src/methods/chunkMap.ts
@@ -13,21 +13,31 @@ export function chunkMap<T, R>(
     objectMode: true,
     ...options,
     async transform(item, _encoding, callback) {
-      chunk.push(item);
-      if (chunk.length >= size) {
-        const result = await method(chunk, index++);
-        this.push(result);
-        chunk = [];
+      try {
+        chunk.push(item);
+        if (chunk.length >= size) {
+          const result = await method(chunk, index++);
+          this.push(result);
+          chunk = [];
+        }
+        callback();
+      } catch (err) {
+        callback(err);
+        this.destroy();
       }
-      callback();
     },
     async flush(callback) {
-      if (chunk.length > 0) {
-        const result = await method(chunk, index++);
-        this.push(result);
-        chunk = [];
+      try {
+        if (chunk.length > 0) {
+          const result = await method(chunk, index++);
+          this.push(result);
+          chunk = [];
+        }
+        callback();
+      } catch (err) {
+        callback(err);
+        this.destroy();
       }
-      callback();
     }
   });
 }

--- a/src/methods/filter.ts
+++ b/src/methods/filter.ts
@@ -15,6 +15,7 @@ export function filter<T>(
         callback(undefined, take ? chunk : undefined);
       } catch (err) {
         callback(err);
+        this.destroy();
       }
     }
   });

--- a/src/methods/from.ts
+++ b/src/methods/from.ts
@@ -4,9 +4,9 @@ import { PassThroughTyped, ReadableTyped } from '../types';
 
 export function from<T>(value: Iterable<T>): PassThroughTyped<T>
 export function from<T>(value: AsyncIterable<T>): PassThroughTyped<T>
-export function from<T>(value: T): PassThroughTyped<T>
 export function from<T>(value: ReadableTyped<T>): PassThroughTyped<T>
 export function from<T>(value: Promise<T>): PassThroughTyped<T>
+export function from<T>(value: T): PassThroughTyped<T>
 export function from<T>(value: any) {
   if (isIterable(value)) return fromIterable<T>(value);
   else if (isPromise(value)) return fromPromise<T>(value);

--- a/src/methods/map.ts
+++ b/src/methods/map.ts
@@ -17,6 +17,7 @@ export function map<T, R>(
         callback();
       } catch (err) {
         callback(err);
+        this.destroy();
       }
     }
   });

--- a/src/methods/reduce.ts
+++ b/src/methods/reduce.ts
@@ -17,6 +17,7 @@ export function reduce<T, R>(
         callback();
       } catch (err) {
         callback(err);
+        this.destroy();
       }
     },
     flush(callback) {

--- a/src/methods/transform.spec.ts
+++ b/src/methods/transform.spec.ts
@@ -67,4 +67,32 @@ describe('transform', () => {
       done();
     });
   });
+
+  it('handles errors by closing stream', (done) => {
+    const check = jest.fn();
+
+    from([1, 2, 3])
+    .pipe(transform(() => {
+      throw new Error('test')
+    }))
+    .on('error', check)
+    .on('close', () => {
+      expect(check.mock.calls.length).toEqual(1);
+      done();
+    });
+  });
+
+  it('handles errors by closing stream', (done) => {
+    const check = jest.fn();
+
+    from([1, 2, 3])
+    .pipe(transform(async () => {
+      throw new Error('test')
+    }))
+    .on('error', check)
+    .on('close', () => {
+      expect(check.mock.calls.length).toEqual(1);
+      done();
+    });
+  });
 });

--- a/src/methods/transform.ts
+++ b/src/methods/transform.ts
@@ -37,6 +37,7 @@ export function transform<In, Out>(
         callback();
       } catch (err) {
         callback(err);
+        this.destroy();
       }
     },
     async flush(callback) {
@@ -50,6 +51,7 @@ export function transform<In, Out>(
         callback();
       } catch (err) {
         callback(err);
+        this.destroy();
       }
     }
   });


### PR DESCRIPTION
- Exposing types allows better compostability with implementations of this library
- If a stream errors, destroy it