### PR TITLE
Fix async calls and pipes

### DIFF
--- a/src/PureStream.spec.ts
+++ b/src/PureStream.spec.ts
@@ -7,14 +7,12 @@ describe('PureStream', () => {
       const source = new PureStream();
       const dest = new PureStream();
 
-      source
-        .pipe(dest)
-        .done((err) => {
-          expect(source.ended).toBe(true);
-          expect(dest.ended).toBe(true);
-          expect(err).toEqual(new Error('test'));
-          done();
-        });
+      source.pipe(dest).done((err) => {
+        expect(source.ended).toBe(true);
+        expect(dest.ended).toBe(true);
+        expect(err).toEqual(new Error('test'));
+        done();
+      });
 
       source.write(1);
       source.destroy(new Error('test'));
@@ -24,14 +22,12 @@ describe('PureStream', () => {
       const source = new PureStream();
       const dest = new PureStream();
 
-      source
-        .pipe(dest)
-        .done((err) => {
-          expect(source.ended).toBe(false);
-          expect(dest.ended).toBe(true);
-          expect(err).toEqual(new Error('test'));
-          done();
-        });
+      source.pipe(dest).done((err) => {
+        expect(source.ended).toBe(false);
+        expect(dest.ended).toBe(true);
+        expect(err).toEqual(new Error('test'));
+        done();
+      });
 
       source.write(1);
       dest.destroy(new Error('test'));
@@ -43,9 +39,12 @@ describe('PureStream', () => {
       const dest2 = new PureStream();
       const dest3 = new PureStream();
 
-      source.pipe(dest1).pipe(dest2).done((err) => {
-        expect(err).toEqual(new Error('test'));
-      });
+      source
+        .pipe(dest1)
+        .pipe(dest2)
+        .done((err) => {
+          expect(err).toEqual(new Error('test'));
+        });
       source.pipe(dest3).done((err) => {
         expect(err).toEqual(new Error('test'));
       });
@@ -64,16 +63,34 @@ describe('PureStream', () => {
 
   describe('wrap', () => {
     it('wraps native stream', (done) => {
-      const source = new PassThrough({objectMode: true});
+      const source = new PassThrough({ objectMode: true });
       const dest = new PureStream();
 
-      PureStream.wrap(source).pipe(dest).done((err) => {
-        expect(err).toEqual(new Error('test'));
-        done();
-      });
+      PureStream.wrap(source)
+        .pipe(dest)
+        .done((err) => {
+          expect(err).toEqual(new Error('test'));
+          done();
+        });
 
       source.write(1);
       source.destroy(new Error('test'));
+    });
+
+    it('wraps native stream with multiple errors', (done) => {
+      const source = new PassThrough({ objectMode: true });
+      const dest = new PureStream();
+
+      PureStream.wrap(source)
+        .pipe(dest)
+        .done((err) => {
+          expect(err).toEqual(new Error('test1'));
+          done();
+        });
+
+      source.write(1);
+      source.emit('error', new Error('test1'));
+      source.destroy(new Error('test2'));
     });
   });
 
@@ -91,10 +108,12 @@ describe('PureStream', () => {
 
       // `each` has occured
       setImmediate(() => expect(check.mock.calls.length).toBe(1));
-      setImmediate(() => stream.done(() => {
-        expect(check.mock.calls.length).toBe(2);
-        done();
-      }));
+      setImmediate(() =>
+        stream.done(() => {
+          expect(check.mock.calls.length).toBe(2);
+          done();
+        })
+      );
       setImmediate(() => stream.end(2));
     });
 
@@ -111,11 +130,13 @@ describe('PureStream', () => {
 
       // `each` has not occured yet
       setImmediate(() => expect(check.mock.calls.length).toBe(0));
-      setImmediate(() => stream.done(() => {
-        expect(check.mock.calls.length).toBe(2);
-        done();
-      }));
+      setImmediate(() =>
+        stream.done(() => {
+          expect(check.mock.calls.length).toBe(2);
+          done();
+        })
+      );
       setImmediate(() => stream.end(2));
-    })
+    });
   });
 });

--- a/src/methods/from.spec.ts
+++ b/src/methods/from.spec.ts
@@ -31,16 +31,13 @@ describe('from', () => {
         expect(check.mock.calls[1][0]).toEqual(2);
         expect(check.mock.calls[2][0]).toEqual(3);
         done();
-      })
+      });
   });
 
   it('Map', (done) => {
     const check = jest.fn();
 
-    from(new Map([
-      ['a', 1],
-      ['b', 2]
-    ]))
+    from(new Map([['a', 1], ['b', 2]]))
       .each(check)
       .done((err) => {
         expect(err).toBe(undefined);
@@ -81,9 +78,21 @@ describe('from', () => {
       });
   });
 
+  it('Promise Rejection', (done) => {
+    const check = jest.fn();
+
+    from(Promise.reject(new Error('test')))
+      .each(check)
+      .done((err) => {
+        expect(err).toEqual(new Error('test'));
+        expect(check.mock.calls.length).toEqual(0);
+        done();
+      });
+  });
+
   it('Stream', (done) => {
     const check = jest.fn();
-    const stream = new PassThrough({objectMode: true});
+    const stream = new PassThrough({ objectMode: true });
 
     from<number>(stream)
       .each(check)
@@ -113,5 +122,5 @@ describe('from', () => {
         expect(check.mock.calls[0][0]).toEqual(1);
         done();
       });
-  })
+  });
 });


### PR DESCRIPTION
Fixes issues around sources piping multiple errors and `from` executing async handlers out of order.